### PR TITLE
When generating template path from url, ignore ports and '.local' suffix...

### DIFF
--- a/squatter/template/loaders/__init__.py
+++ b/squatter/template/loaders/__init__.py
@@ -13,9 +13,14 @@ class Loader(BaseLoader):
     is_usable = True
 
     def load_template_source(self, template_name, template_dirs=None):
-        site = get_site()
+        
+        site = get_site().domain.split(':')[0]
+        if site.endswith('.local'):
+            site = site[:-6]
+        site = site.replace('.', '_')
+
         for dir_ in settings.TEMPLATE_DIRS:
-            path = os.path.join(dir_, site.domain, template_name)
+            path = os.path.join(dir_, site, template_name)
             try:
                 return open(path).read(), template_name
             except IOError:


### PR DESCRIPTION
...es

this behaviour will need some documentation too.
