### PR TITLE
Handle get_site returning None. Remove port and '.local' suffix before c...

### DIFF
--- a/squatter/template/loaders/__init__.py
+++ b/squatter/template/loaders/__init__.py
@@ -8,16 +8,23 @@ import settings
 
 from squatter.utils import get_site
 
-
 class Loader(BaseLoader):
     is_usable = True
 
     def load_template_source(self, template_name, template_dirs=None):
+        
         site = get_site()
-        for dir_ in settings.TEMPLATE_DIRS:
-            path = os.path.join(dir_, site.domain, template_name)
-            try:
-                return open(path).read(), template_name
-            except IOError:
-                pass
+        if site:
+            site = site.domain.split(':')[0]
+            if site.endswith('.local'):
+                site = site[:-6]
+            site = site.replace('.', '_')
+
+            for dir_ in settings.TEMPLATE_DIRS:
+                path = os.path.join(dir_, site, template_name)
+                print path
+                try:
+                    return open(path).read(), template_name
+                except IOError:
+                    pass
         raise TemplateDoesNotExist, template_name


### PR DESCRIPTION
...onverting domain to template path.

This supercedes my previous patch. Ignore that one.
